### PR TITLE
Fix: Align database configurations and improve connection logic

### DIFF
--- a/app1/connections.py
+++ b/app1/connections.py
@@ -10,7 +10,34 @@ MONGODB = settings.MONGODB
 
 # MongoDB and Elasticsearch clients in one line each
 def get_mongo_client():
-    return MongoClient(f"mongodb://{MONGODB['USER']}:{MONGODB['PASSWORD']}@{MONGODB['HOST']}:{MONGODB['PORT']}/{MONGODB['NAME']}")
+    host = MONGODB['HOST']
+    port = MONGODB['PORT']
+    db_name = MONGODB['NAME']
+    user = MONGODB.get('USER')
+    password = MONGODB.get('PASSWORD')
+
+    if user and password:
+        uri = f"mongodb://{user}:{password}@{host}:{port}/{db_name}"
+    else:
+        uri = f"mongodb://{host}:{port}/{db_name}"
+    return MongoClient(uri)
 
 def get_els_client():
-    return Elasticsearch([{'host': ELASTICSEARCH['HOST'], 'port': ELASTICSEARCH['PORT']}], http_auth=(ELASTICSEARCH['USER'], ELASTICSEARCH['PASSWORD']), use_ssl=ELASTICSEARCH['USE_SSL'])
+    host = ELASTICSEARCH['HOST']
+    port = ELASTICSEARCH['PORT']
+    use_ssl = ELASTICSEARCH['USE_SSL']
+    user = ELASTICSEARCH.get('USER')
+    password = ELASTICSEARCH.get('PASSWORD')
+
+    if user and password:
+        client = Elasticsearch(
+            [{'host': host, 'port': port}],
+            http_auth=(user, password),
+            use_ssl=use_ssl
+        )
+    else:
+        client = Elasticsearch(
+            [{'host': host, 'port': port}],
+            use_ssl=use_ssl
+        )
+    return client

--- a/app1/models_dbs.py
+++ b/app1/models_dbs.py
@@ -6,7 +6,7 @@ from elasticsearch.exceptions import RequestError
 import json
 from decimal import Decimal
 
-from settings import MONGODB, ELASTICSEARCH
+from django.conf import settings
 
 
 class ProductMongo(Document):
@@ -46,18 +46,18 @@ class ElasticsearchManager:
     def __init__(self):
         # Build Elasticsearch connection URL
         auth = None
-        if ELASTICSEARCH.get('USER') and ELASTICSEARCH.get('PASSWORD'):
-            auth = (ELASTICSEARCH['USER'], ELASTICSEARCH['PASSWORD'])
+        if settings.ELASTICSEARCH.get('USER') and settings.ELASTICSEARCH.get('PASSWORD'):
+            auth = (settings.ELASTICSEARCH['USER'], settings.ELASTICSEARCH['PASSWORD'])
 
-        scheme = 'https' if ELASTICSEARCH.get('USE_SSL', False) else 'http'
-        host = f"{scheme}://{ELASTICSEARCH['HOST']}:{ELASTICSEARCH['PORT']}"
+        scheme = 'https' if settings.ELASTICSEARCH.get('USE_SSL', False) else 'http'
+        host = f"{scheme}://{settings.ELASTICSEARCH['HOST']}:{settings.ELASTICSEARCH['PORT']}"
 
         self.es = Elasticsearch(
             [host],
             http_auth=auth,
-            verify_certs=ELASTICSEARCH.get('USE_SSL', False)
+            verify_certs=settings.ELASTICSEARCH.get('USE_SSL', False)
         )
-        self.index_name = ELASTICSEARCH['INDEX_NAME']
+        self.index_name = settings.ELASTICSEARCH['INDEX_NAME']
 
     def create_index(self):
         """Create Elasticsearch index with mapping"""
@@ -140,19 +140,19 @@ def setup_mongodb():
     """Setup MongoDB connection and create indexes"""
     try:
         # Build MongoDB URI
-        if MONGODB.get('USER') and MONGODB.get('PASSWORD'):
-            mongo_uri = f"mongodb://{MONGODB['USER']}:{MONGODB['PASSWORD']}@{MONGODB['HOST']}:{MONGODB['PORT']}/{MONGODB['NAME']}"
+        if settings.MONGODB.get('USER') and settings.MONGODB.get('PASSWORD'):
+            mongo_uri = f"mongodb://{settings.MONGODB['USER']}:{settings.MONGODB['PASSWORD']}@{settings.MONGODB['HOST']}:{settings.MONGODB['PORT']}/{settings.MONGODB['NAME']}"
         else:
-            mongo_uri = f"mongodb://{MONGODB['HOST']}:{MONGODB['PORT']}/{MONGODB['NAME']}"
+            mongo_uri = f"mongodb://{settings.MONGODB['HOST']}:{settings.MONGODB['PORT']}/{settings.MONGODB['NAME']}"
 
         # Connect to MongoDB
         mongoengine.connect(
-            db=MONGODB['NAME'],
+            db=settings.MONGODB['NAME'],
             host=mongo_uri,
             alias='default'
         )
 
-        print(f"Connected to MongoDB: {MONGODB['NAME']}")
+        print(f"Connected to MongoDB: {settings.MONGODB['NAME']}")
 
         # Create indexes (they will be created automatically when first document is saved)
         # But we can ensure they exist by calling ensure_indexes
@@ -179,7 +179,7 @@ def setup_elasticsearch():
 
         # Create index
         if es_manager.create_index():
-            print(f"Elasticsearch index '{ELASTICSEARCH['INDEX_NAME']}' is ready")
+            print(f"Elasticsearch index '{settings.ELASTICSEARCH['INDEX_NAME']}' is ready")
             return True, es_manager
         else:
             return False, None
@@ -220,7 +220,7 @@ def main():
     print("=" * 50)
 
     print("\n📊 MONGODB:")
-    print(f"   Database Name: {MONGODB['NAME']}")
+    print(f"   Database Name: {settings.MONGODB['NAME']}")
     print(f"   Collection (Table) Name: products")
     print("   Fields:")
     print("     - name (StringField, max_length=200)")
@@ -235,7 +235,7 @@ def main():
     print("     - (category, price) (compound index)")
 
     print("\n🔍 ELASTICSEARCH:")
-    print(f"   Index Name: {ELASTICSEARCH['INDEX_NAME']}")
+    print(f"   Index Name: {settings.ELASTICSEARCH['INDEX_NAME']}")
     print("   Fields (Mapping):")
     print("     - name (text, analyzed)")
     print("     - category (keyword, for exact match)")

--- a/dbs_test/settings.py
+++ b/dbs_test/settings.py
@@ -80,9 +80,9 @@ WSGI_APPLICATION = 'dbs_test.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'benchmark_db',
-        'USER': 'a13431343',
-        'PASSWORD': 'postgres',
+        'NAME': 'postgres',
+        'USER': 'postgres',
+        'PASSWORD': 'a13431343',
         'HOST': 'localhost',
         'PORT': '5431',
         'CONN_MAX_AGE': 600,  # Connection pooling
@@ -94,10 +94,10 @@ DATABASES = {
 # MongoDB Configuration
 MONGODB = {
     'HOST': 'localhost',        # MongoDB host
-    'PORT': 27017,             # MongoDB port
+    'PORT': 27016,             # MongoDB port
     'NAME': 'myproject_db',    # MongoDB database name
-    'USER': 'mongo_user',      # Optional: MongoDB username
-    'PASSWORD': 'mongo_pass',  # Optional: MongoDB password
+    #'USER': 'mongo_user',      # Optional: MongoDB username
+    #'PASSWORD': 'mongo_pass',  # Optional: MongoDB password
 }
 
 # Elasticsearch Configuration
@@ -105,8 +105,8 @@ ELASTICSEARCH = {
     'HOST': 'localhost',           # Elasticsearch host
     'PORT': 9200,                 # Elasticsearch port
     'INDEX_NAME': 'products',     # Elasticsearch index name
-    'USER': 'elastic_user',       # Optional: Elasticsearch username
-    'PASSWORD': 'elastic_pass',   # Optional: Elasticsearch password
+    #'USER': 'elastic_user',       # Optional: Elasticsearch username
+    #'PASSWORD': 'elastic_pass',   # Optional: Elasticsearch password
     'USE_SSL': False,             # Optional: Use HTTPS
 }
 


### PR DESCRIPTION
This commit addresses inconsistencies between Docker Compose definitions and Django settings for PostgreSQL, MongoDB, and Elasticsearch.

Key changes:
- Updated `dbs_test/settings.py`:
    - PostgreSQL: Corrected DB name, user, and password to match docker-compose.
    - MongoDB: Corrected port to match host mapping (27016) and removed authentication details as the container is not configured for it.
    - Elasticsearch: Removed authentication details as the container has security disabled.
- Refactored `app1/connections.py`:
    - MongoDB and Elasticsearch client functions now conditionally include authentication details based on their presence in settings, preventing errors when credentials are not configured.
- Refactored `app1/models_dbs.py`:
    - Changed direct settings import to use `django.conf.settings` for consistency.
- Reviewed `docker/elasticsearch.yml`: Confirmed its settings are appropriate and align with the configuration changes.

These changes aim to ensure a smoother setup and connection process for all three databases when running the project with Docker Compose. I encountered some limitations with the Docker Compose setup that prevented me from fully testing the Dockerized environment.